### PR TITLE
Remove reliance on hard-coded paths 

### DIFF
--- a/logo_gui.cpp
+++ b/logo_gui.cpp
@@ -41,35 +41,6 @@ void logo_gui::load_logo(string bundle_path)
 		check_file.close();
 	}
 
-	if (!logo_loaded)
-	{
-		file_name.str("");
-		file_name  << "/usr/lib/lv2/triceratops.lv2/logo.png";
-		ifstream check_file(file_name.str() );
-		if (check_file)
-		{
-			cout << "loading " << file_name.str() << endl;
-			// Load pixbuf
-			image_ptr_ = Gdk::Pixbuf::create_from_file (file_name.str().c_str()); 
-			logo_loaded = true;
-		}
-		check_file.close();
-	}
-
-	if (!logo_loaded)
-	{
-		file_name.str("");
-		file_name  << "/usr/local/lib/lv2/triceratops.lv2/logo.png";
-		ifstream check_file(file_name.str() );
-		if (check_file)
-		{
-			cout << "loading " << file_name.str() << endl;
-			// Load pixbuf
-			image_ptr_ = Gdk::Pixbuf::create_from_file (file_name.str().c_str());
-			logo_loaded = true;
-		}
-		check_file.close();
-	}
 
 
 

--- a/presets.h
+++ b/presets.h
@@ -125,7 +125,7 @@ class presets : public Gtk::DrawingArea
 
 	// FUNCTIONS USED IN THIS CLASS
 
-	presets();
+	presets(const std::string& bundle_path_in);
 	~presets();
 	void position_top(bool);
 	int pos_mode;

--- a/triceratops.ttl
+++ b/triceratops.ttl
@@ -16,7 +16,7 @@ guiext:requiredFeature guiext:makeResident.
 
 <http://nickbailey.co.nr/triceratops>
 	a lv2:Plugin ,
-		lv2:AmplifierPlugin ;
+		lv2:InstrumentPlugin ;
 	doap:maintainer <http://nickbailey.co.nr> ;
 	doap:name "Triceratops" ;
 	doap:license <http://opensource.org/licenses/gpl-3.0> ;

--- a/triceratops_gui.cpp
+++ b/triceratops_gui.cpp
@@ -78,11 +78,11 @@ static GtkWidget* make_gui(triceratopsGUI *self) {
 	// check for default config file
 
 	string config_file_name = "";
-	ifstream check_file("/usr/lib/lv2/triceratops.lv2/triceratops.conf" );
-	if (check_file) config_file_name = "/usr/local/lib/lv2/triceratops.lv2/triceratops.conf";
-	check_file.open("/usr/local/lib/lv2/triceratops.lv2/triceratops.conf" );
-	if (check_file) config_file_name = "/usr/local/lib/lv2/triceratops.lv2/triceratops.conf";
-	
+
+	string bundle_config_name = string(self->bundle_path) + string("triceratops.conf");
+	ifstream check_file(bundle_config_name);
+	if (check_file) config_file_name = bundle_config_name;
+
 	if (config_file_name !="");
 	{
 		string temp_str;
@@ -155,7 +155,7 @@ static GtkWidget* make_gui(triceratopsGUI *self) {
 	self->vbox2 = new Gtk::VBox();
 	self->vbox3 = new Gtk::VBox();
 
-	self->widget_presets = new presets();
+	self->widget_presets = new presets(self->bundle_path);
 
 	self->widget_presets->top_colour = top_colour;
 	self->widget_presets->bottom_colour = bottom_colour;
@@ -188,10 +188,10 @@ static GtkWidget* make_gui(triceratopsGUI *self) {
 	self->logo3 = new logo_gui();
 	self->logo4 = new logo_gui();
 
-	self->logo1->load_logo("/usr/local/lib/lv2/triceratops.lv2/");
-	self->logo2->load_logo("/usr/local/lib/lv2/triceratops.lv2/");
-	self->logo3->load_logo("/usr/local/lib/lv2/triceratops.lv2/");
-	self->logo4->load_logo("/usr/local/lib/lv2/triceratops.lv2/");
+	self->logo1->load_logo(self->bundle_path);
+	self->logo2->load_logo(self->bundle_path);
+	self->logo3->load_logo(self->bundle_path);
+	self->logo4->load_logo(self->bundle_path);
 
 	self->logo1->top_colour.set(top_colour.to_string());
 	self->logo1->bottom_colour.set(bottom_colour.to_string());


### PR DESCRIPTION
Use the LV2 bundle path to find associated files as well as the presets. This makes it possible to install the plugin to non-standard paths.

- Also fix a crash while drawing the GUI when the presets list happens to be empty.
- Another commit changes the type of LV2 plugin to InstrumentPlugin, which seems to be the right category.