### PR TITLE
Replace lv2core by lv2

### DIFF
--- a/wscript
+++ b/wscript
@@ -34,7 +34,7 @@ def configure(conf):
         	conf.env.append_unique('CXXFLAGS', ['-fPIC','-fpermissive','-finline-functions'])
 
     if not autowaf.is_child():
-        autowaf.check_pkg(conf, 'lv2core', uselib_store='LV2CORE')
+        autowaf.check_pkg(conf, 'lv2', uselib_store='LV2CORE')
         autowaf.check_pkg(conf, 'gtkmm-2.4', uselib_store='GTKMM')
 
     # Set env['pluginlib_PATTERN']


### PR DESCRIPTION
When building lv2 from git, triceratops fails because it cannot find lv2 any
more.

Reason: lv2core.pc was removed in lv2 [1].

Using lv2.pc works perfectly fine - the contents of both files in lv2 version
1.14 are similar from pkg-config point of view.

[1] https://github.com/drobilla/lv2/commit/4db67120efca2d4c200d2e1ba5cf3d7b97cab97e

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>