### PR TITLE
fix: don't export any symbols except LV2 descriptor

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import os
-import sys 
+import sys
 import shutil
 from waflib import Logs
 from waflib.extras import autowaf as autowaf
@@ -18,16 +18,17 @@ def options(opt):
     opt.load('compiler_cxx')
     autowaf.set_options(opt)
 
-def configure(conf):	
+def configure(conf):
     conf.load('compiler_c')
     conf.load('compiler_cxx')
     autowaf.configure(conf)
     autowaf.display_header('triceratops Configuration')
-   
+
     if conf.env['MSVC_COMPILER']:
         conf.env.append_unique('CXXFLAGS', ['-TP', '-MD', '-g'])
     else:
-        conf.env.append_unique('CXXFLAGS', ['-O2','-funroll-loops','-std=c++0x','-g'])
+        conf.env.append_unique('CXXFLAGS',
+            ['-O2', '-funroll-loops', '-fvisibility=hidden', '-std=c++0x', '-g'])
 
     if sys.maxsize >= 9223372036854775807:
         print("detected 64 bit architecture, enabling -fPIC")
@@ -88,7 +89,7 @@ def build(bld):
               install_path = '${LV2DIR}/%s' % bundle,
               uselib       = 'LV2CORE',
               includes     = includes)
-    
+
     # Build UI library
     obj = bld(features     = 'cxx cshlib',
               env          = penv,
@@ -103,7 +104,3 @@ def build(bld):
     bld.install_files('${LV2DIR}/triceratops.lv2/', 'triceratops.conf')
     bld.install_files('${LV2DIR}/triceratops.lv2/', 'triceratops_categories.txt')
     bld.install_files('${LV2DIR}/triceratops-presets.lv2', bld.path.ant_glob('presets.lv2/*.*'))
-
-
-
-


### PR DESCRIPTION
Fixes these `lv2lint` erros and is generally a good idea:

```

<http://nickbailey.co.nr/triceratops>
    [FAIL]  Plugin Symbols
              binary exports superfluous globally visible symbols: 
                * _ZN7inertiaD2Ev
                * _ZN7nixecho5resetEv
                * _ZN5synthD2Ev
                * _ZN6DLineND2Ev
                * _Z8do_3bandP7EQSTATEd
                * _ZN6FilterD0Ev
                * _ZN3LFOC1Ef
                * _ZN6Reverb4tickEd
                * _ZN5noiseC1Ev
                * _ZN6ReverbC2Ev
                * ... there is more, but the rest is being truncated
              seeAlso: <http://lv2plug.in/ns/lv2core#binary>
lv2ui_descriptor(0) called
  <http://nickbailey.co.nr/triceratops/gui>
    [FAIL]  UI Symbols
              binary exports superfluous globally visible symbols: 
                * _ZN6volume9set_valueEf
                * _ZN7presets14set_gui_widgetEif
                * _ZN6toggle9set_valueEi
                * _ZN7presets21on_button_press_eventEP15_GdkEventButton
                * _ZN5faderD0Ev
                * _ZTv0_n32_N8logo_guiD1Ev
                * _ZN10reverb_guiD0Ev
                * _ZN7dco_guiC2EiNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES5_
                * _ZN6spacer15on_expose_eventEP15_GdkEventExpose
                * _ZN6toggle9set_labelENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
                * ... there is more, but the rest is being truncated
              seeAlso: <http://lv2plug.in/ns/lv2core#binary>
    [WARN]  UI Toolkit
              usage of non-native toolkit <http://lv2plug.in/ns/extensions/ui#GtkUI> is dicouraged
              seeAlso: <http://lv2plug.in/ns/extensions/ui#ui>
```